### PR TITLE
Patch v1.7.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
     - name: Upload executable
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{env.EXEC}}
         path: ${{github.workspace}}/build/Release/${{env.EXEC}}
@@ -75,7 +75,7 @@ jobs:
     - name: run packaging script
       run: python3 gui/packaging/package.py
     - name: Upload packaging scripts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: package-metadata
         path: |
@@ -100,12 +100,12 @@ jobs:
         tools: 'tools_ifw tools_opensslv3_x64'
         cache: true
     - name: Download artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{env.EXEC}}
         path: gui/packaging/packages/com.vendor.product/data/
     - name: Download installer metadata
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: package-metadata
         path: ${{github.workspace}}/gui/packaging
@@ -119,7 +119,7 @@ jobs:
         ${{github.workspace}}\..\Qt\Tools\QtInstallerFramework\4.7\bin\binarycreator.exe -c config\config.xml -p packages ${{env.PROGNAME}}-installer-win64.exe
       working-directory: gui/packaging
     - name: Upload installer
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{env.PROGNAME}}-installer-win64.exe
         path: gui/packaging/${{env.PROGNAME}}-installer-win64.exe
@@ -132,7 +132,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
     - name: Download artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{env.PROGNAME}}-installer-win64.exe
         path: ./
@@ -177,7 +177,7 @@ jobs:
         cmake ../firmware
         make -j
     - name: Upload firmware .uf2 file
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{env.FIRMWARE}}.uf2
         path: ./build/${{env.FIRMWARE}}.uf2
@@ -189,7 +189,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
     - name: Download artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{env.FIRMWARE}}.uf2
         path: ./
@@ -222,7 +222,7 @@ jobs:
         make -j
         cp -v ${{env.FIRMWARE}}.uf2 ${{env.FIRMWARE2}}.uf2
     - name: Upload firmware .uf2 file
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{env.FIRMWARE2}}.uf2
         path: ./build/${{env.FIRMWARE2}}.uf2
@@ -234,7 +234,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
     - name: Download artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{env.FIRMWARE2}}.uf2
         path: ./

--- a/gui/src/config.h
+++ b/gui/src/config.h
@@ -22,7 +22,7 @@
 #define _CONFIG_H
 
 #define PROGRAM_NAME "PICO SST39sf0x0 Programmer"
-#define PROGRAM_VERSION "1.7.1"
+#define PROGRAM_VERSION "1.7.2"
 #define UNUSED(x) (void)(x)
 
 #endif // _CONFIG_H

--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -214,10 +214,10 @@ void MainWindow::build_rom_selection_menu(QVBoxLayout* target_layout) {
      * MULTICARTRIDGE IMAGES
      */
     // create toplevel interface
-    this->multirom_container = new QGroupBox("Multicard images");
-    this->multirom_container->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
+    this->rom_container = new QGroupBox("ROM images");
+    this->rom_container->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
     QVBoxLayout *layout = new QVBoxLayout();
-    this->multirom_container->setLayout(layout);
+    this->rom_container->setLayout(layout);
 
     // add individual buttons here
     QPushButton* btn1 = new QPushButton("P2000T Multicart ROM");
@@ -230,31 +230,17 @@ void MainWindow::build_rom_selection_menu(QVBoxLayout* target_layout) {
     layout->addWidget(btn2);
     connect(btn2, SIGNAL(released()), this, SLOT(load_default_image()));
 
-    target_layout->addWidget(this->multirom_container);
-
-    /**
-     * SINGLE ROM IMAGES
-     */
-
-    // create toplevel interface
-    this->singlerom_container = new QGroupBox("Single cartridge images");
-    this->singlerom_container->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
-    layout = new QVBoxLayout();
-    this->singlerom_container->setLayout(layout);
-
     // add individual buttons here
-    btn1 = new QPushButton("P2000T BASICNL v1.1");
-    btn1->setProperty("image_name", QVariant(QString("https://github.com/p2000t/software/raw/refs/heads/main/cartridges/BASICNL1.1.bin")));
-    layout->addWidget(btn1);
-    connect(btn1, SIGNAL(released()), this, SLOT(load_default_image()));
-
-    // add individual buttons here
-    btn2 = new QPushButton("Select other ROM");
-    layout->addWidget(btn2);
+    QPushButton* btn3 = new QPushButton("Select other ROM");
+    layout->addWidget(btn3);
 
     // list of ROM images
     QList<QPair<QString, QString>> rom_images = {
-        {"P2000T Games Bundle", "https://github.com/ifilot/p2000t-rompacks/releases/download/nightly/GAMES-128KiB.BIN"},
+        {"P2000T BASICNL v1.1", "https://github.com/p2000t/software/raw/refs/heads/main/cartridges/BASICNL1.1.bin"},
+        {"P2000T Games Bundle (8-pack; 128 KiB; Space Fight)", "https://github.com/ifilot/p2000t-rompacks/releases/download/nightly/GAMES-128KiB.BIN"},
+        {"P2000T Games Bundle (8-pack; 128 KiB; Fraxxon)", "https://github.com/ifilot/p2000t-rompacks/releases/download/nightly/GAMES-128KiB-ALT.BIN"},
+        {"P2000T Games Bundle (16-pack; 256 KiB)", "https://github.com/ifilot/p2000t-rompacks/releases/download/nightly/GAMES-256KiB.BIN"},
+        {"P2000T Joystick ROM", "https://github.com/ifilot/p2000t-joystick-cartridge/releases/download/nightly/joystick_eeprom.bin"},
         {"Assembler v5.9", "https://github.com/p2000t/software/raw/refs/heads/main/cartridges/assembler%205.9.bin"},
         {"BASICNL with Bootstrap for SD-CARD cartridge", "https://github.com/ifilot/p2000t-sdcard/releases/latest/download/BASICBOOTSTRAP.BIN"},
         {"Familiegeheugen v4", "https://github.com/p2000t/software/raw/refs/heads/main/cartridges/familiegeheugen%204.bin"},
@@ -274,9 +260,9 @@ void MainWindow::build_rom_selection_menu(QVBoxLayout* target_layout) {
         connect(action, &QAction::triggered, this, &MainWindow::load_default_image);
         rommenu->addAction(action);
     }
-    btn2->setMenu(rommenu);
+    btn3->setMenu(rommenu);
 
-    target_layout->addWidget(this->singlerom_container);
+    target_layout->addWidget(this->rom_container);
 }
 
 /**
@@ -729,9 +715,7 @@ void MainWindow::slot_update_settings() {
     //qDebug() << "Settings update triggered";
 
     bool show_retroroms = this->settings.value("SHOW_RETROROMS", QVariant(true)).toBool();
-    this->multirom_container->setVisible(show_retroroms);
-    this->singlerom_container->setVisible(show_retroroms);
-    dynamic_cast<QWidget*>(this->singlerom_container->parent())->layout()->invalidate();
+    this->rom_container->setVisible(show_retroroms);
     this->hex_widget->viewport()->repaint();
 }
 

--- a/gui/src/mainwindow.h
+++ b/gui/src/mainwindow.h
@@ -111,8 +111,7 @@ private:
     QLabel* label_compile_data;
     QSettings settings;
 
-    QGroupBox *multirom_container;
-    QGroupBox *singlerom_container;
+    QGroupBox *rom_container;
 
 public:
     /**


### PR DESCRIPTION
Removing the distinction between "multirom" and "single rom" binaries. By default, the P2000T Multirom and the C64 Multirom are shown and a drop-down menu for all other ROMS.